### PR TITLE
[DONE] Remove property ``has_groundwater`` from...

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,9 @@ History
 0.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove property ``has_groundwater`` from ``GridH5Admin``.
+  Should always be provided by the threedicore itself. Gives a warning for
+  backwards compatibility.
 
 
 0.1.2 (2018-03-12)

--- a/tests/test_gridadmin.py
+++ b/tests/test_gridadmin.py
@@ -248,12 +248,39 @@ class GridAdminCellsTest(unittest.TestCase):
         )
 
     def test_get_id_from_xy(self):
-
-        self.assertIsNone(self.parser.cells.get_id_from_xy(1.,2.))
+        # should yield tow ids, one for 2d, one for groundwater
+        self.assertListEqual(self.parser.cells.get_id_from_xy(1.,2.), [])
         # first coordinate pair + some offset
         x = self.parser.cells.coordinates[0][1] + 0.5
         y = self.parser.cells.coordinates[1][1] + 0.5
-        self.assertEqual(self.parser.cells.get_id_from_xy(x,y), 1)
+        self.assertListEqual(self.parser.cells.get_id_from_xy(x,y), [1, 6537])
+
+    def test_get_id_from_xy_2d_open_water(self):
+
+        self.assertListEqual(
+            self.parser.cells.get_id_from_xy(
+                1.,2., subset_name='2d_open_water'), [])
+        # first coordinate pair + some offset
+        x = self.parser.cells.coordinates[0][1] + 0.5
+        y = self.parser.cells.coordinates[1][1] + 0.5
+        self.assertEqual(
+            self.parser.cells.get_id_from_xy(
+                x,y, subset_name='2d_open_water'
+            ), [1]
+        )
+
+    def test_get_id_from_xy_groundwater(self):
+
+        self.assertListEqual(self.parser.cells.get_id_from_xy(
+            1.,2., subset_name='groundwater_all'), [])
+        # first coordinate pair + some offset
+        x = self.parser.cells.coordinates[0][1] + 0.5
+        y = self.parser.cells.coordinates[1][1] + 0.5
+        self.assertEqual(
+            self.parser.cells.get_id_from_xy(
+                x,y, subset_name='groundwater_all'
+            ), [6537]
+        )
 
     def test_exporters(self):
         self.assertEqual(len(self.parser.cells._exporters), 1)

--- a/threedigrid/admin/gridadmin.py
+++ b/threedigrid/admin/gridadmin.py
@@ -156,15 +156,16 @@ class GridH5Admin(object):
     def model_slug(self):
         return self.h5py_file.attrs['model_slug']
 
-    @property
-    def has_groundwater(self):
-        # TODO threedicore will provide info, change accordingly
-        return self.nodes.has_groundwater
-
     def _set_props(self):
         for prop, value in self.h5py_file.attrs.iteritems():
             if prop and prop.startswith('has_'):
-                setattr(self, prop, bool(value))
+                try:
+                    setattr(self, prop, bool(value))
+                except AttributeError:
+                    logger.warning(
+                        'Can not set property {}, already exists'.format(prop)
+                    )
+                    pass
 
     @property
     def has_levees(self):

--- a/threedigrid/admin/nodes/models.py
+++ b/threedigrid/admin/nodes/models.py
@@ -142,9 +142,7 @@ class Cells(Nodes):
         if subset_name:
             inst = self.subset(subset_name)
         id = inst.filter(cell_coords__contains_point=xy).id
-        if id.size == 1:
-            return int(id[0])
-        return None
+        return id.tolist()
 
     def __repr__(self):
         return "<orm cells instance of {}>".format(self.model_name)

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -226,11 +226,6 @@ class Model:
             self.__class__, [SliceFilter(slice_filter)] + self.slice_filters)
 
     @property
-    def has_groundwater(self):
-        req = self.subset('2D_GROUNDWATER').data
-        return len(req['id']) > 0
-
-    @property
     def known_subset(self):
         if not hasattr(self, 'SUBSETS'):
             return "has no subsets defined"


### PR DESCRIPTION
…``GridH5Admin``. Should always be provided by the threedicore itself. Gives a warning for backwards compatibility.