### PR TITLE
[Done] Using a non-tuple sequence for multidimensional indexing is deprecate…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,10 +4,13 @@ History
 1.0.5 (unreleased)
 ------------------
 
-- Split requirements file to allow for finer grained builds (for instance to
-  generate the documentation).
+- Using a non-tuple sequence for multidimensional indexing is deprecated; use
+  `arr[tuple(seq)]` instead of `arr[seq]`.
 
 - Add 'intercepted_volume' to NodesAggregateResultsMixin.
+
+- Split requirements file to allow for finer grained builds (for instance to
+  generate the documentation).
 
 
 1.0.4 (2018-10-17)

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -216,7 +216,7 @@ class Model(six.with_metaclass(ABCMeta)):
             value = value[:]
 
         # Perform slicing by applying the mask
-        value = value[_filter]
+        value = value[tuple(_filter)]
 
         # Reproject any coordinates if a reproject_to_epsg is set and
         # there are coordinatefields in the selection


### PR DESCRIPTION
…d; use `arr[tuple(seq)]` instead of `arr[seq]`