### PR TITLE
[DUPLICATE] Fixed __repr__ of model not working in python3.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 1.0.5 (unreleased)
 ------------------
 
+- Fixed __repr__ of base models for python3.
+
 - Split requirements file to allow for finer grained builds (for instance to
   generate the documentation).
 

--- a/tests/test_gridadmin.py
+++ b/tests/test_gridadmin.py
@@ -20,6 +20,7 @@ from threedigrid.admin.constants import SUBSET_1D_ALL
 from threedigrid.admin.constants import SUBSET_2D_OPEN_WATER
 from threedigrid.admin.constants import NO_DATA_VALUE
 from six.moves import range
+from six import string_types
 
 test_file_dir = os.path.join(
     os.getcwd(), "tests/test_files")
@@ -195,6 +196,10 @@ class GridAdminNodeTest(unittest.TestCase):
         s = ogr.Open(self.f)
         lyr = s.GetLayer()
         self.assertEqual(lyr.GetFeatureCount(), self.parser.nodes.id.size)
+
+    def test_repr(self):
+        name = self.parser.nodes.__repr__()
+        self.assertTrue(isinstance(name, string_types))
 
 
 class GridAdminBreachTest(unittest.TestCase):

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -117,11 +117,12 @@ class Model(six.with_metaclass(ABCMeta)):
     @property
     def model_name(self):
         try:
-            model_name = '-'.join(
-                (self._datasource.getattr('model_name'),
-                 self._datasource.getattr('model_slug'),
-                 str(self._datasource.getattr('revision_nr')),
-                 self._datasource.getattr('revision_hash')))
+            model_name_args = (self._datasource.getattr('model_name'),
+                               self._datasource.getattr('model_slug'),
+                               self._datasource.getattr('revision_nr'),
+                               self._datasource.getattr('revision_hash'))
+            model_name_args = map(lambda x: x.decode('utf-8'), model_name_args)
+            model_name = '-'.join(model_name_args)
         except (AttributeError, KeyError):
             model_name = 'unknown'
             pass


### PR DESCRIPTION
It was trying to join a numpy.byte with a python3 string which failed. This caused an error every time you call `ga.nodes` for example.