### PR TITLE
[DONE] Added to_structured_array method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 1.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added `to_structured_array` method for retrieving (filtered) results
+  as Numpy structured array instead of an OrderedDict
 
 
 1.0.8 (2019-01-03)

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -526,6 +526,22 @@ class Model(six.with_metaclass(ABCMeta)):
 
         return selection
 
+    def to_structured_array(self):
+        """
+        :return: the filtered values as a
+        structured (named) array
+        """
+        selection = self.to_dict()
+
+        # Convert the dictionary to structured array
+        dtypes = []
+        for key, value in selection.items():
+            dtypes.append((key, value.dtype.name, value.shape))
+
+        return np.array(
+            [tuple([selection[x[0]] for x in dtypes])],
+            dtype=dtypes)[0]
+
     def to_list(self):
         """
         :return: list of dicts with key's and values


### PR DESCRIPTION
Structured array's are easier sent over a binary communication channel.

Also saves some space compared to storing the orderddict in an numpy array directly.

len(np.array(gr.nodes.data).tobytes()) = 1343053 
len(gr.nodes.to_structured_array.tobytes()) = 1062784

1062784 / 1343053 = 0.7913194788292048