### PR TITLE
[Working] livesite manhole info 1) not visible or 2) wrong manhole info THREEDI-698

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 1.0.9 (unreleased)
 ------------------
 
+- Manholes preparation fixed mapping in ``connection_node_pk``.
 - Added `to_structured_array` method for retrieving (filtered) results
   as Numpy structured array instead of an OrderedDict
 

--- a/threedigrid/admin/nodes/prepare.py
+++ b/threedigrid/admin/nodes/prepare.py
@@ -87,7 +87,7 @@ class PrepareManholes:
             threedi_datasource.v2_manholes, [
                 'pk', 'surface_level', 'display_name', 'bottom_level',
                 'calculation_type', 'shape', 'drain_level', 'width',
-                'manhole_indicator', 'zoom_category'])
+                'manhole_indicator', 'zoom_category', 'connection_node_pk'])
 
         # extra field to distinguish manholes from connection nodes.
         is_manhole = np.full(len(threedi_datasource.v2_manholes), True)
@@ -98,4 +98,4 @@ class PrepareManholes:
             ['surface_level', 'display_name', 'bottom_level',
              'calculation_type', 'shape', 'drain_level', 'width',
              'manhole_indicator', 'zoom_category', 'is_manhole'],
-            manhole_numpy_array_dict['pk'], content_pk)
+            manhole_numpy_array_dict['connection_node_pk'], content_pk)


### PR DESCRIPTION
**Dit lijkt op eerste zicht een frontend probleem, maar wellicht is het gewoon een mapping probleem.**

------------------------------------------------------------------------------------------------------------------------------------
Dit is een productie bug die 2-ledig is:
1. als een manhole op een `connection_node` ligt (dat kan), dan wordt in de livesite de info van de `connection_node` getoond (en niet vd manhole!)
2. als een manhole niet op een `connection_node` ligt (dat kan), dan wordt in de livesite de info van de verkeerder manhole getoond (mapping probleem denk ik). Bovendien is dan het resultaat (grafiek waterstand etc) dan ook van een andere manhole (volgens Bram en Leendert)

Het probleem komt voor in het hedensted_integral model voor (maar volgens mij gebeurt het in alle modellen met `connection_nodes` en manholes.

wellicht maakt het nog uit dat in het hedensted model ALLE `connection_nodes` een manhole hebben (dat hoeft niet zo te zijn in andere modellen).

**model_slug**:
demomodelslvw-t0093_hedensted_integral_default-28-0bf216b5e6c7aeb7f519d6c1d416906cfe0d6342