### PR TITLE
[For review] livesite manhole info 1) not visible or 2) wrong manhole info THREEDI-698

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 1.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bug fix in `h5py_file` method mapping.
 
 
 1.0.10 (2019-01-31)

--- a/threedigrid/admin/gridresultadmin.py
+++ b/threedigrid/admin/gridresultadmin.py
@@ -122,7 +122,7 @@ class GridH5ResultAdmin(GridH5Admin):
             )
 
     @property
-    def __field_model_map(self):
+    def _field_model_map(self):
         """
         :return: a dict of {<field name>: [model name, ...]}
         """
@@ -135,7 +135,12 @@ class GridH5ResultAdmin(GridH5Admin):
             if any([attr_name.startswith('__'),
                     attr_name.startswith('_')]):
                 continue
-            attr = getattr(self, attr_name)
+            try:
+                attr = getattr(self, attr_name)
+            except AttributeError:
+                logger.warning("Attribute: '{}' does not "
+                               "exist in h5py_file.".format(attr_name))
+                continue
             if not issubclass(type(attr), Model):
                 continue
             model_names.add(attr_name)
@@ -151,7 +156,7 @@ class GridH5ResultAdmin(GridH5Admin):
         :return: instance of the model the field belongs to
         :raises IndexError if the field name is not unique across models
         """
-        model_name = self.__field_model_map.get(field_name)
+        model_name = self._field_model_map.get(field_name)
         if not model_name or len(model_name) != 1:
             raise IndexError(
                 'Ambiguous result. Field name {} yields {} model(s)'.format(


### PR DESCRIPTION
**Dit lijkt op eerste zicht een frontend probleem, maar wellicht is het gewoon een mapping probleem.**

------------------------------------------------------------------------------------------------------------------------------------
Dit is een productie bug die 2-ledig is:
1. als een manhole op een `connection_node` ligt (dat kan), dan wordt in de livesite de info van de `connection_node` getoond (en niet vd manhole!)
2. als een manhole niet op een `connection_node` ligt (dat kan), dan wordt in de livesite de info van de verkeerder manhole getoond (mapping probleem denk ik). Bovendien is dan het resultaat (grafiek waterstand etc) dan ook van een andere manhole (volgens Bram en Leendert)

Het probleem komt voor in het hedensted_integral model voor (maar volgens mij gebeurt het in alle modellen met `connection_nodes` en manholes.

wellicht maakt het nog uit dat in het hedensted model ALLE `connection_nodes` een manhole hebben (dat hoeft niet zo te zijn in andere modellen).

**model_slug**:
demomodelslvw-t0093_hedensted_integral_default-28-0bf216b5e6c7aeb7f519d6c1d416906cfe0d6342