### PR TITLE
[DONE] Updated pyproj and fixed speed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ History
 1.0.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bumped package versions
+
+- Reduced reprojection overhead of line_geometries.
 
 
 1.0.16 (2019-07-08)

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,4 +1,4 @@
 h5py==2.9.0
 ipython==5.8.0
-numpy==1.17.1
+numpy==1.16.5
 cftime==1.0.3.4

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,4 +1,4 @@
-h5py==2.8.0
-ipython==5.5.0
-numpy==1.13.1
-cftime==1.0.1
+h5py==2.9.0
+ipython==7.8.0
+numpy==1.17.1
+cftime==1.0.3.4

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,4 +1,4 @@
 h5py==2.9.0
-ipython==7.8.0
+ipython==5.8.0
 numpy==1.17.1
 cftime==1.0.3.4

--- a/requirements_geo.txt
+++ b/requirements_geo.txt
@@ -1,7 +1,7 @@
 -r requirements_base.txt
 
 pygdal==2.2.2.3
-pyproj==2.3.1
+pyproj==2.2.2
 Shapely==1.6.4
 mercantile==1.1.2
 geojson==2.5.0

--- a/requirements_geo.txt
+++ b/requirements_geo.txt
@@ -1,7 +1,7 @@
 -r requirements_base.txt
 
 pygdal==2.2.2.3
-pyproj==1.9.5.1
+pyproj==2.3.1
 Shapely==1.6.4
-mercantile==1.0.1
-geojson==2.3.0
+mercantile==1.1.2
+geojson==2.5.0


### PR DESCRIPTION
- pyproj >= 2.0.1 has a lot more overhead for initializing projections. Reduced the overhead
  by creating a 'Transform' once and reusing it.
- Updated/bumped Python package versions.
