### PR TITLE
[DONE] Raise AttributeError instead of logging

### DIFF
--- a/tests/test_h5py_datasource.py
+++ b/tests/test_h5py_datasource.py
@@ -1,0 +1,13 @@
+import pytest
+
+from threedigrid.admin.h5py_datasource import H5pyGroup
+
+
+def test_init_existing_h5py_group(h5py_file):
+    datasource = H5pyGroup(h5py_file, 'nodes')
+    assert datasource is not None
+
+
+def test_init_missing_h5py_group(h5py_file):
+    with pytest.raises(AttributeError):
+        H5pyGroup(h5py_file, 'doesnotexist')

--- a/threedigrid/admin/h5py_datasource.py
+++ b/threedigrid/admin/h5py_datasource.py
@@ -140,11 +140,9 @@ class H5pyGroup(DataSource):
 
     def __init__(self, h5py_file, group_name, meta=None, required=False):
         if group_name not in list(h5py_file.keys()) and not required:
-            logger.info(
-                '[*] {0} not found in file {1}, not required...'.format(
-                    group_name, h5py_file)
+            raise AttributeError(
+                "{0} has no group '{1}'".format(h5py_file, group_name)
             )
-            return
 
         self.group_name = group_name
 


### PR DESCRIPTION
Updating from threedigrid `1.0.18` to `1.0.19` introduced a bug in `has_levees` (and the other `has_*`). The function now raises an attribute error when the gridadmin file is missing the group. For example with the model Texel.

This is caused due to the removal of the following two lines:
https://github.com/nens/threedigrid/blob/2683b0185657f316673de86edd31f0c58301dbcc/threedigrid/orm/base/models.py#L93
In `1.0.18` this would raise an `AttributeError`  in https://github.com/nens/threedigrid/blob/2683b0185657f316673de86edd31f0c58301dbcc/threedigrid/admin/h5py_datasource.py#L51 because the `_h5py_file` was never set.

In this PR I suggest raising the `AttributeError` directly when trying to instantiate the `H5pyGroup` instead of only logging an info message. It seems like the behaviour is again the same as it was in `1.0.18` with this fix, i.e.:
- calling `ga.has_levees` returns False and no longer raises an AttributeError
- calling `ga.levees` raises an AttributeError
