### PR TITLE
[DONE] _get_subset_idx bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pip install -r requirements_geo.txt -e .
 
 before_script:
-  - pip install flake8 sphinx
+  - pip install flake8 sphinx==1.8.5
 
 script:
   - pytest

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 1.0.20.6 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Bugfix for `Model._get_subset_idx` not instantiating new subsets with their parent's
+  mixins.
 
 
 1.0.20.5 (2020-04-01)

--- a/tests/test_gridresultadmin.py
+++ b/tests/test_gridresultadmin.py
@@ -158,6 +158,10 @@ def test_gr_get_subset_idx_leak(gr):
 def test_gr_get_subset_ids_no_composite_field(gr):
     assert gr.nodes._get_subset_idx('s1') is None
 
+
+def test_gr_chain_filter(gr):
+    assert gr.nodes.filter(id=4).get_filtered_field_value('leak').shape == (9, 1)
+
 # commented for now until the new aggregate.nc is finished
 
 # def test_get_node_aggregate_netcdf_results(agg_gr):

--- a/tests/test_gridresultadmin.py
+++ b/tests/test_gridresultadmin.py
@@ -151,6 +151,13 @@ def test_get_model_instance_by_field_name_raises_index_error(gr):
         gr.get_model_instance_by_field_name("zoom_category")
 
 
+def test_gr_get_subset_idx_leak(gr):
+    assert gr.nodes._get_subset_idx('leak').shape == (10748,)
+
+
+def test_gr_get_subset_ids_no_composite_field(gr):
+    assert gr.nodes._get_subset_idx('s1') is None
+
 # commented for now until the new aggregate.nc is finished
 
 # def test_get_node_aggregate_netcdf_results(agg_gr):

--- a/tests/test_gridresultadmin.py
+++ b/tests/test_gridresultadmin.py
@@ -160,7 +160,8 @@ def test_gr_get_subset_ids_no_composite_field(gr):
 
 
 def test_gr_chain_filter(gr):
-    assert gr.nodes.filter(id=4).get_filtered_field_value('leak').shape == (9, 1)
+    assert gr.nodes.filter(
+        id=4).get_filtered_field_value('leak').shape == (9, 1)
 
 # commented for now until the new aggregate.nc is finished
 

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -158,7 +158,7 @@ class Model(six.with_metaclass(ABCMeta)):
         :param field_name: field name
         """
         new_inst = self.__init_class(
-            self.__class__, **{})
+            self.__class__, **self.class_kwargs)
         subset_dict = new_inst.Meta.subset_fields.get(field_name)
         if not subset_dict:
             return

--- a/threedigrid/orm/base/models.py
+++ b/threedigrid/orm/base/models.py
@@ -158,7 +158,7 @@ class Model(six.with_metaclass(ABCMeta)):
         :param field_name: field name
         """
         new_inst = self.__init_class(
-            self.__class__, **self.class_kwargs)
+            self.__class__, **{'mixin': self.class_kwargs.get('mixin')})
         subset_dict = new_inst.Meta.subset_fields.get(field_name)
         if not subset_dict:
             return


### PR DESCRIPTION
Bug seems to be introduced upgrading from `1.0.18` to `1.0.19`.
It caused an attribute error when trying to get a `BASE_COMPOSITE_FIELD` from the gridresultadmin, for example: `gr.nodes.leak`
