### PR TITLE
Context manager

### DIFF
--- a/threedigrid/admin/gridadmin.py
+++ b/threedigrid/admin/gridadmin.py
@@ -268,10 +268,10 @@ class GridH5Admin(object):
             return x
 
     def __enter__(self):
-        return self.h5py_file
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        self.h5py_file.close()
 
     def close(self):
         self.h5py_file.flush()


### PR DESCRIPTION
Allow the gridadmin to be opened with a context manager and be sure that it will be closed.

Previously it would return the h5py file, but it makes more sense (to me) to return the gridadmin in the threedigrid package. If someone want to use the h5py.File, he/she should use that package instead.

However, this does break the api, i.e. its not backwards compatible! Maybe we should first throw a deprecation warning?

```python3
with GridH5Admin(h5_file) as ga:
    ga.nodes.id

with GridH5ResultAdmin(h5_file, nc_file) as gr:
    gr.nodes.id
    gr.nodes.s1

gr.h5py_file
# returns: <Closed HDF5 file>

```