### PR TITLE
Geopackage exporter: Remove width constraint of 32 on string fields

### DIFF
--- a/threedigrid/admin/exporters/geopackage/exporter.py
+++ b/threedigrid/admin/exporters/geopackage/exporter.py
@@ -162,9 +162,7 @@ class GpkgExporter(BaseOgrExporter):
                 field = ogr.FieldDefn(
                     ogr_field_name, const.OGR_FIELD_TYPE_MAP[field_type]
                 )
-                if field_type in ("str", str):
-                    field.SetWidth(32)
-                elif field_type in ("bool", bool):
+                if field_type in ("bool", bool):
                     field.SetSubType(ogr.OFSTBoolean)
 
                 layer.CreateField(field)


### PR DESCRIPTION
Reason for this change: some schematisations have e.g. pumps with display names > 32 characters. Somehow they are written correctly to the geopackage, even though the field has a constraint of 32 characters max. But when we try to copy the layer later on, it leads to errors.

@jpprins1 I could not think of a reason to put a constraint on the width of string fields in the gridadmin geopackage export. So I removed it altogether. But you may have had reasons to set this 32 max width which I am not aware of.

I did test to convert a h5 file to geopackage with this new code, and it works + solves the problem outlined above